### PR TITLE
Fix of tests broken release build

### DIFF
--- a/src/cryptonote_basic/cryptonote_basic_impl.cpp
+++ b/src/cryptonote_basic/cryptonote_basic_impl.cpp
@@ -163,7 +163,7 @@ namespace cryptonote {
     return 21;
   }
 
-  inline uint64_t get_base_reward(uint64_t already_generated_coins)
+  uint64_t get_base_reward(uint64_t already_generated_coins)
   {
     const auto current_window = get_current_reward_window(already_generated_coins);
     auto reward = get_reward_for_reward_window(current_window);


### PR DESCRIPTION
Remove inlining of _get_base_reward_ as it is optimized out and breaks build of core tests