### PR TITLE
Changed sweep_unmixable min required size

### DIFF
--- a/src/advancedwallet/advancedwallet.cpp
+++ b/src/advancedwallet/advancedwallet.cpp
@@ -91,8 +91,6 @@ typedef cryptonote::advanced_wallet sw;
 #define MULTISIG_ACTIVE 0 //multisig is not yet implemented for tokens
 #define BLACKBALL_ACTIVE 0 //blackball is not yet needed, we are starting blokcchain from scratch
 
-#define DEFAULT_MIX 6
-
 #define MIN_RING_SIZE 7 // Used to inform user about min ring size -- does not track actual protocol
 
 #define OUTPUT_EXPORT_FILE_MAGIC "Safex output export\003"

--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -145,6 +145,8 @@
 #define HF_VERSION_MIN_MIXIN_6                  HF_VERSION_TBD
 #define HF_VERSION_ENFORCE_RCT                  HF_VERSION_TBD //enforce RingCT transactions
 
+#define DEFAULT_MIX                             6 //default wallet mix for transactions
+
 #define PER_KB_FEE_QUANTIZATION_DECIMALS        6
 
 #define HASH_OF_HASHES_STEP                     256

--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -88,8 +88,6 @@ typedef cryptonote::simple_wallet sw;
 
 #define ENABLE_ADVANCED_OPTIONS 0 //some aditional features
 
-#define DEFAULT_MIX 6
-
 #define MIN_RING_SIZE 7 // Used to inform user about min ring size -- does not track actual protocol
 
 #define OUTPUT_EXPORT_FILE_MAGIC "Safex output export\003"

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -9782,15 +9782,15 @@ const wallet::transfer_details &wallet::get_transfer_details(size_t idx) const
 //----------------------------------------------------------------------------------------------------
 std::vector<size_t> wallet::select_available_unmixable_outputs(bool trusted_daemon, cryptonote::tx_out_type out_type)
 {
-  // request all outputs with less than 3 instances
-  const size_t min_mixin = 2;
+  // request all outputs with less than 7 instances
+  const size_t min_mixin = DEFAULT_MIX;
   return select_available_outputs_from_histogram(min_mixin + 1, false, true, false, trusted_daemon, out_type);
 }
 //----------------------------------------------------------------------------------------------------
 std::vector<size_t> wallet::select_available_mixable_outputs(bool trusted_daemon, cryptonote::tx_out_type out_type)
 {
-  // request all outputs with at least 3 instances, so we can use mixin 2 with
-  const size_t min_mixin = 2;
+  // request all outputs with at least 7 instances, so we can use mixin 6 with
+  const size_t min_mixin = DEFAULT_MIX;
   return select_available_outputs_from_histogram(min_mixin + 1, true, true, true, trusted_daemon, out_type);
 }
 //----------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Fixed problem with transaction failing with default ring size 7
and sweep_unmixable reporting that there are no unmixable outputs (checked for ring size 3)