### PR TITLE
Remove libzmq from macOS build instructions. Package NLA/unnecessary.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,6 @@ Install all libraries
 ```
 $ brew tap jmuncaster/homebrew-header-only
 $ brew install cmake boost zmq czmq zeromq jmuncaster/header-only/cppzmq openssl pkg-config
-$ brew install libzmq
 ```
 You will need to have MacPorts installed. If you don't have it install it from here https://guide.macports.org/. Download the package for your OS version from the website. Open **new** terminal window and check if MacPorts are installed
 ```


### PR DESCRIPTION
`brew install libzmq` on macOS returns Error: No available formula with the name "libzmq"

this package is no longer available (NLA) from homebrew and can be replaced with zeromq (installed in the prior step)