### PR TITLE
Fix build with Boost 1.69

### DIFF
--- a/src/cryptonote_basic/miner.cpp
+++ b/src/cryptonote_basic/miner.cpp
@@ -631,7 +631,7 @@ namespace cryptonote
         boost::tribool battery_powered(on_battery_power());
         if(!indeterminate( battery_powered ))
         {
-          on_ac_power = !(bool)battery_powered;
+          on_ac_power = !static_cast<bool>(battery_powered);
         }
       }
 

--- a/src/cryptonote_basic/miner.cpp
+++ b/src/cryptonote_basic/miner.cpp
@@ -631,7 +631,7 @@ namespace cryptonote
         boost::tribool battery_powered(on_battery_power());
         if(!indeterminate( battery_powered ))
         {
-          on_ac_power = !battery_powered;
+          on_ac_power = !(bool)battery_powered;
         }
       }
 


### PR DESCRIPTION
This fixes build failing when building with Boost 1.69 (specifically on ArchLinux).
```
src/cryptonote_basic/miner.cpp:640:25: error: assigning to 'bool' from incompatible type 'boost::logic::tribool'
          on_ac_power = !battery_powered;
                        ^~~~~~~~~~~~~~~~
```
See:
https://github.com/monero-project/monero/pull/4700