### PR TITLE
output format fix for get_my_interest

### DIFF
--- a/src/simplewallet/simplewallet_safex.cpp
+++ b/src/simplewallet/simplewallet_safex.cpp
@@ -692,7 +692,7 @@ namespace cryptonote
     success_msg_writer() << boost::format("%30s %20s") % tr("Output amount") % tr("Available interest");
     for(auto& pair : interest_per_output)
     {
-      success_msg_writer() << boost::format("%30s %20s") % pair.first % print_money(pair.second);
+      success_msg_writer() << boost::format("%30s %20s") % print_money(pair.first) % print_money(pair.second);
     }
     return true;
   }


### PR DESCRIPTION
Simple fix to get the output of get_my_interest to show a decimal point.  Images show before and after:
![image](https://user-images.githubusercontent.com/57327308/68439461-4e116200-018d-11ea-9694-189658079e18.png)
![image](https://user-images.githubusercontent.com/57327308/68439478-58336080-018d-11ea-88b4-1c2dcd930773.png)
