### PR TITLE
changes to get Windows build to work

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -542,10 +542,10 @@ else()
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-strict-aliasing")
 
   # if those don't work for your compiler, single it out where appropriate
-  if(CMAKE_BUILD_TYPE STREQUAL "Release")
-    set(C_SECURITY_FLAGS "${C_SECURITY_FLAGS} -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=1")
-    set(CXX_SECURITY_FLAGS "${CXX_SECURITY_FLAGS} -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=1")
-  endif()
+#  if(CMAKE_BUILD_TYPE STREQUAL "Release")
+#    set(C_SECURITY_FLAGS "${C_SECURITY_FLAGS} -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=1")
+#    set(CXX_SECURITY_FLAGS "${CXX_SECURITY_FLAGS} -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=1")
+#  endif()
 
   # warnings
   add_c_flag_if_supported(-Wformat C_SECURITY_FLAGS)

--- a/contrib/epee/include/include_base_utils.h
+++ b/contrib/epee/include/include_base_utils.h
@@ -31,4 +31,7 @@
 
 #include "misc_log_ex.h"
 
+#ifndef uint
+#define uint unsigned long long
+#endif
 

--- a/contrib/epee/include/string_tools.h
+++ b/contrib/epee/include/string_tools.h
@@ -29,6 +29,10 @@
 #ifndef _STRING_TOOLS_H_
 #define _STRING_TOOLS_H_
 
+#ifndef uint
+#define uint unsigned long long
+#endif
+
 // Previously pulled in by ASIO, further cleanup still required ...
 #ifdef _WIN32
 # include <winsock2.h>

--- a/src/simplewallet/simplewallet_common.cpp
+++ b/src/simplewallet/simplewallet_common.cpp
@@ -4,6 +4,8 @@
 #include <fstream>
 #include <ctype.h>
 #include <boost/lexical_cast.hpp>
+#include <boost/locale/encoding.hpp>
+#include <boost/locale/generator.hpp>
 #include <boost/program_options.hpp>
 #include <boost/algorithm/string.hpp>
 #include <boost/format.hpp>


### PR DESCRIPTION
These are the changes I made to get my Windows build working.  I can't say for sure if any of these changes can safely be made without negatively affecting the integrity of the final build, but they did result in a successful build with binaries that seemed to work.

CMakeLists.txt: There was an error around something called __memchk toward the end of the build process that had to do with "fortify source" which led me to this file.  I commented out that section to get around the issue.  

include_base_utils.h and string_tools.h :  I got the "uint not defined" error several times and just tried to find some header files that looked like they were included by a lot of cpp classes so that I could provide a definition if none existed.  I mapped it to "unsigned long long" because the first line of code where I got the error calls another function that returns an unsigned long long and assigns the result to a "uint."  I am concerned that if this isn't the right mapping, some arithmetic could be off somewhere in the code.   Also, I think there has to be a better way of doing this without changing code in contrib/epee which seems like code that shouldn't be changed.

simplewallet_common.cpp: There were two errors related to unreferenced boost hpp files.  I searched the documentation to find the needed functions and added includes for them which resolved the issues.   I don't know anything about boost other than what I just read today in the documentation.

I did everything else according to the readme file and I didn't have to install any additional dependencies.  I hope this helps!