### PR TITLE
Fix safex_acccount new not catching missing params

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,5 @@
 # Safex Project
-#
 
-#
-
-#
 
 ## Releases
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Safex Project
+#
 
+#
+
+#
 
 ## Releases
 

--- a/src/simplewallet/simplewallet_safex.cpp
+++ b/src/simplewallet/simplewallet_safex.cpp
@@ -856,8 +856,12 @@ namespace cryptonote
     local_args.erase(local_args.begin());
     if (command == "new")
     {
-      const std::string &username = local_args[0];
+      if (local_args.size() != 2){
+        fail_msg_writer() << tr("usage: safex_account new <account_username> <account_data>");        
+        return true;
+      }
 
+      const std::string &username = local_args[0];
       std::ostringstream accdata_ostr;
       std::copy(local_args.begin() + 1, local_args.end(), ostream_iterator<string>(accdata_ostr, " "));
       const std::string accdata_str = accdata_ostr.str();


### PR DESCRIPTION
Function
Safex_account new <username>

Expected Result
Error saying that account data is required.  Otherwise there's no indication that the command was used incorrectly and the account does not appear in the safex_account list.

Result
 No output whatsover. 

How to replicate
Run the command safex_account new <username> without any account data.

Fix
The safex_account new requires two parameters, so added a check to make sure there are at least two parameters passed in.